### PR TITLE
update pom to version 4.10 and add escape to jelly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	  </parent>
 
 	<properties>
-		<jenkins.version>2.204.1</jenkins.version>
+		<jenkins.version>2.222.1</jenkins.version>
 		<java.level>8</java.level>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,19 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	
 	<modelVersion>4.0.0</modelVersion>
-	
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>1.541</version>
-	</parent>
+		<version>4.10</version>
+		<relativePath />
+	  </parent>
+
+	<properties>
+		<jenkins.version>2.204.1</jenkins.version>
+		<java.level>8</java.level>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
+	</properties>
 
 	<artifactId>hidden-parameter</artifactId>
 	<packaging>hpi</packaging>	
@@ -65,8 +72,4 @@
 		</pluginRepository>
 	</pluginRepositories>
 	
-	<properties>
-      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-      <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    </properties>
 </project>

--- a/src/main/resources/com/wangyin/parameter/WHideParameterDefinition/config.jelly
+++ b/src/main/resources/com/wangyin/parameter/WHideParameterDefinition/config.jelly
@@ -1,9 +1,10 @@
-  <!-- This jelly script is used for per-project configuration. See global.jelly 
+  <!-- This jelly script is used for per-project configuration. See global.jelly
 	for a general discussion about jelly script. -->
 
-<!-- Creates a text field that shows the value of the "name" property. When 
+<!-- Creates a text field that shows the value of the "name" property. When
 	submitted, it will be passed to the corresponding constructor parameter. -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">

--- a/src/main/resources/com/wangyin/parameter/WHideParameterDefinition/index.jelly
+++ b/src/main/resources/com/wangyin/parameter/WHideParameterDefinition/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">

--- a/src/main/resources/com/wangyin/parameter/WHideParameterValue/value.jelly
+++ b/src/main/resources/com/wangyin/parameter/WHideParameterValue/value.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">


### PR DESCRIPTION
The motivation for the PR is to fix the failing checks. I was unable to get the checks passing with the current POM version, I therefor updated the pom to version 4.10 (following the recommendation from https://github.com/jenkinsci/plugin-pom#java-support) and added `<?jelly escape-by-default='true'?>` as required by InjectedTest. 

The Jenkins version has set to 2.222.1 as recommended in https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/#currently-recommended-versions

@wy-scm, @oleg-nenashev 