### PR TITLE
Hacktoberfest: Modernize plugin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+  target-branch: master
+  reviewers:
+  - wy-scm
+  labels:
+  - skip-changelog

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Maven build files
+target/
+
+# Jenkins plugin development
+work/
+
+# IntelliJ project files
+*.iml
+*.ipr
+*.iws
+.idea/*
+!.idea/codeStyles/
+
+# Ignore generated files.
+.project
+.classpath
+.settings
+.factorypath
+*/.classpath
+*/.factorypath
+*/.project
+*/.settings
+
+# Backup file from pom parent updates
+pom.xml.versionsBackup

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.2</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/pom.xml
+++ b/pom.xml
@@ -4,22 +4,27 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>4.10</version>
-		<relativePath />
-	  </parent>
-
-	<properties>
-		<jenkins.version>2.222.1</jenkins.version>
-		<java.level>8</java.level>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-	</properties>
+		<version>4.29</version>
+	</parent>
 
 	<artifactId>hidden-parameter</artifactId>
 	<packaging>hpi</packaging>
-	<version>0.0.6-SNAPSHOT</version>
+	<version>${revision}${changelist}</version>
 	<name>Hidden Parameter plugin</name>
-    <url>http://wiki.jenkins-ci.org/display/JENKINS/Hidden+Parameter+Plugin</url>
+    <url>https://github.com/jenkinsci/hidden-parameter-plugin</url>
+
+	<properties>
+	  <revision>0.0.6</revision>
+      <changelist>-SNAPSHOT</changelist>
+      <gitHubRepo>jenkinsci/hidden-parameter-plugin</gitHubRepo>
+	  <jenkins.version>2.289.1</jenkins.version>
+	  <java.level>8</java.level>
+	  <spotbugs.effort>Max</spotbugs.effort>
+	  <spotbugs.failOnError>true</spotbugs.failOnError>
+	  <spotbugs.threshold>Low</spotbugs.threshold>
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
 
 	<organization>
 		<name>wangyin</name>
@@ -46,10 +51,11 @@
 	</build>
 
 	<scm>
-        <connection>scm:git:git://github.com/jenkinsci/hidden-parameter-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:jenkinsci/hidden-parameter-plugin.git</developerConnection>
-      <tag>HEAD</tag>
-  </scm>
+        <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+        <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    	<url>https://github.com/${gitHubRepo}</url>
+     	<tag>${scmTag}</tag>
+    </scm>
 
 	<repositories>
 		<repository>
@@ -64,5 +70,4 @@
 			<url>https://repo.jenkins-ci.org/public/</url>
 		</pluginRepository>
 	</pluginRepositories>
-
 </project>

--- a/src/main/java/com/wangyin/parameter/WHideParameterDefinition.java
+++ b/src/main/java/com/wangyin/parameter/WHideParameterDefinition.java
@@ -3,12 +3,14 @@
  */
 package com.wangyin.parameter;
 
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
+
 import hudson.Extension;
 import hudson.model.ParameterDefinition;
 import hudson.model.ParameterValue;
 import net.sf.json.JSONObject;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
 
 /**
  * @author wy-scm wy-scm@jd.com
@@ -16,25 +18,27 @@ import org.kohsuke.stapler.StaplerRequest;
  */
 public class WHideParameterDefinition extends ParameterDefinition {
 
-	private static final long serialVersionUID = 8296806777255584941L;
-	private String defaultValue;
+    private static final long serialVersionUID = 8296806777255584941L;
+    private String defaultValue;
 
-	public String getDefaultValue() {
-		return defaultValue;
-	}
+    public String getDefaultValue() {
+        return defaultValue;
+    }
 
-	public void setDefaultValue(String defaultValue) {
-		this.defaultValue = defaultValue;
-	}
+    public void setDefaultValue(String defaultValue) {
+        this.defaultValue = defaultValue;
+    }
 
     @DataBoundConstructor
-	public WHideParameterDefinition(String name,String defaultValue, String description) {
-		super(name, description);
-		this.defaultValue = defaultValue;
-	}
+    public WHideParameterDefinition(String name, String defaultValue, String description) {
+        super(name);
+        this.defaultValue = defaultValue;
+        setDescription(description);
+    }
 
     @Extension
-	public static class DescriptorImpl extends ParameterDescriptor {
+    @Symbol({ "hidden", "hiddenParam" })
+    public static class DescriptorImpl extends ParameterDescriptor {
         @Override
         public String getDisplayName() {
             return "Hidden Parameter";
@@ -42,33 +46,26 @@ public class WHideParameterDefinition extends ParameterDefinition {
     }
 
     @Override
-	public WHideParameterValue getDefaultParameterValue() {
-    	WHideParameterValue v = new WHideParameterValue(getName(),defaultValue, getDescription());
-		return v;
-	}
+    public WHideParameterValue getDefaultParameterValue() {
+        WHideParameterValue v = new WHideParameterValue(getName(), defaultValue, getDescription());
+        return v;
+    }
 
-
-
-	public ParameterValue createValue(StaplerRequest req) {
+    public ParameterValue createValue(StaplerRequest req) {
         String[] value = req.getParameterValues(getName());
         if (value == null) {
             return getDefaultParameterValue();
         } else if (value.length != 1) {
-            throw new IllegalArgumentException("Illegal number of parameter values for " + getName() + ": " + value.length);
+            throw new IllegalArgumentException(
+                    "Illegal number of parameter values for " + getName() + ": " + value.length);
         } else {
             return new WHideParameterValue(getName(), value[0], getDescription());
         }
-	}
+    }
 
-
-	public ParameterValue createValue(StaplerRequest req, JSONObject jo) {
-		WHideParameterValue value = req.bindJSON(WHideParameterValue.class, jo);
+    public ParameterValue createValue(StaplerRequest req, JSONObject jo) {
+        WHideParameterValue value = req.bindJSON(WHideParameterValue.class, jo);
         value.setDescription(getDescription());
-		return value;
-	}
-
-	public static void main(String[] args) {
-
-	}
-
+        return value;
+    }
 }

--- a/src/main/java/com/wangyin/parameter/WHideParameterValue.java
+++ b/src/main/java/com/wangyin/parameter/WHideParameterValue.java
@@ -10,13 +10,13 @@ import hudson.model.StringParameterValue;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
-* @author wy-scm wy-scm@jd.com
-*/
+ * @author wy-scm wy-scm@jd.com
+ */
 public class WHideParameterValue extends StringParameterValue {
 
-	private static final long serialVersionUID = 6926027508686211675L;
+    private static final long serialVersionUID = 6926027508686211675L;
 
-	@DataBoundConstructor
+    @DataBoundConstructor
     public WHideParameterValue(String name, String value) {
         super(name, value);
     }

--- a/src/main/resources/com/wangyin/parameter/WHideParameterDefinition/config.jelly
+++ b/src/main/resources/com/wangyin/parameter/WHideParameterDefinition/config.jelly
@@ -1,8 +1,3 @@
-  <!-- This jelly script is used for per-project configuration. See global.jelly
-	for a general discussion about jelly script. -->
-
-<!-- Creates a text field that shows the value of the "name" property. When
-	submitted, it will be passed to the corresponding constructor parameter. -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"

--- a/src/test/java/com/wangyin/parameter/WHideParameterDefinitionTest.java
+++ b/src/test/java/com/wangyin/parameter/WHideParameterDefinitionTest.java
@@ -1,0 +1,35 @@
+package com.wangyin.parameter;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.ParameterValue;
+import hudson.model.ParametersAction;
+import hudson.model.ParametersDefinitionProperty;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class WHideParameterDefinitionTest {
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
+
+    @Test
+    public void testFreestylePipeline() throws Exception {
+
+        final String defaultValue = "default_value_from_hidden_parameter";
+
+        WHideParameterDefinition param = new WHideParameterDefinition("MY_HIDDEN_PARAMETER", defaultValue,
+                "my hidden value");
+        FreeStyleProject job = jenkins.createProject(FreeStyleProject.class, "test-projet");
+        job.addProperty(new ParametersDefinitionProperty(param));
+
+        FreeStyleBuild completedBuild = jenkins.assertBuildStatusSuccess(job.scheduleBuild2(0));
+        ParametersAction parameterAction = completedBuild.getAction(ParametersAction.class);
+
+        ParameterValue paramValue = parameterAction.getParameter("MY_HIDDEN_PARAMETER");
+        assertEquals(paramValue.getValue(), defaultValue);
+    }
+}


### PR DESCRIPTION
The purpose is to update the plugin to take advantage of the most recent parent pom, and also add the ability to generate snippets for declarative pipeline.

The steps are provided in https://bit.ly/contributing-to-open-source

Another motivation is that the [WMI Windows Agents](https://plugins.jenkins.io/windows-slaves/) is installed automatically along side hidden-parameter-plugin, was removed from core after hidden-parameter-plugin was last updated. 

- update parent pom from **1.542** to **4.29**
- add `escape-by-default` to jelly templates which is required by the parent pom update
- require **Jenkins 2.289.1** as minimum version
- use https:// instead of git:// in pom scm section
- add .gitignore to ease development
- enable spotbugs Mac effort with lowest threshold
- add `Symbols` to allow for generating pipeline snippets
- add simple test for the parameter definition
- add dependabot with `wy-scm` as reviewer
- enable incremental build support 
 
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
