### PR TITLE
Stop setting `pluginFirstClassLoader`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,13 +30,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.jenkins-ci.tools</groupId>
-				<artifactId>maven-hpi-plugin</artifactId>
-				<configuration>
-					<pluginFirstClassLoader>true</pluginFirstClassLoader>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>


### PR DESCRIPTION
It's not needed for this plugin which doesn't bundle any libraries.