### PR TITLE
Fix dependabot config after rename master to main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,5 @@ updates:
 - package-ecosystem: maven
   directory: "/"
   schedule:
-    interval: monthly
-  open-pull-requests-limit: 10
-  target-branch: master
+    interval: weekly
+


### PR DESCRIPTION
Fix dependabot config after rename master to main

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
