### PR TITLE
Make plugin works with Rebuild plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,11 @@
   </dependencyManagement>
 
   <dependencies>
+    <dependency>
+      <groupId>com.sonyericsson.hudson.plugins.rebuild</groupId>
+      <artifactId>rebuild</artifactId>
+      <optional>true</optional>
+    </dependency>
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/com/wangyin/parameter/WHideParameterProvider.java
+++ b/src/main/java/com/wangyin/parameter/WHideParameterProvider.java
@@ -1,0 +1,44 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2025
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.wangyin.parameter;
+
+import com.sonyericsson.rebuild.RebuildParameterPage;
+import com.sonyericsson.rebuild.RebuildParameterProvider;
+import hudson.Extension;
+import hudson.model.ParameterValue;
+
+/**
+ * An extension class to inject {@link WHideParameterValue} to rebuild-plugin.
+ */
+@Extension(optional = true)
+public class WHideParameterProvider extends RebuildParameterProvider {
+
+    @Override
+    public RebuildParameterPage getRebuildPage(ParameterValue value) {
+        if (value instanceof WHideParameterValue) {
+            return new RebuildParameterPage(WHideParameterValue.class, "rebuild.jelly");
+        }
+        return null;
+    }
+}

--- a/src/main/resources/com/wangyin/parameter/WHideParameterValue/rebuild.jelly
+++ b/src/main/resources/com/wangyin/parameter/WHideParameterValue/rebuild.jelly
@@ -1,0 +1,12 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
+         xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
+  <j:set var="escapeEntryTitleAndDescription" value="false"/>
+  <f:entry title="${h.escape(it.name)}" description="${it.formattedDescription}">
+    <div name="parameter" description="${it.description}">
+      <input type="hidden" name="name" value="${it.name}"/>
+      <f:textbox name="value" value="${it.value}" readonly="true"/>
+    </div>
+  </f:entry>
+</j:jelly>

--- a/src/test/java/com/wangyin/parameter/WHideParameterProviderTest.java
+++ b/src/test/java/com/wangyin/parameter/WHideParameterProviderTest.java
@@ -1,0 +1,86 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2025
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.wangyin.parameter;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.sonyericsson.rebuild.RebuildAction;
+import hudson.model.Cause;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.ParameterValue;
+import hudson.model.ParametersAction;
+import hudson.model.ParametersDefinitionProperty;
+import java.util.List;
+import org.htmlunit.WebClient;
+import org.htmlunit.html.HtmlForm;
+import org.htmlunit.html.HtmlPage;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+public class WHideParameterProviderTest {
+
+    @Test
+    public void testRebuild(JenkinsRule jenkins) throws Exception {
+
+        final String defaultValue = "default_value_from_hidden_parameter";
+
+        WHideParameterDefinition param =
+                new WHideParameterDefinition("MY_HIDDEN_PARAMETER", defaultValue, "my hidden value");
+        FreeStyleProject job = jenkins.createProject(FreeStyleProject.class, "test-project");
+        job.addProperty(new ParametersDefinitionProperty(param));
+
+        FreeStyleBuild build1 = job.scheduleBuild2(
+                        0,
+                        new Cause.UserIdCause(),
+                        List.of(new ParametersAction(new WHideParameterValue(
+                                "MY_HIDDEN_PARAMETER", "value-from-run", "description-from-run"))))
+                .get();
+        jenkins.assertBuildStatusSuccess(build1);
+
+        // now try to rebuild
+        try (WebClient wc = jenkins.createWebClient()) {
+            HtmlPage page = wc.getPage(jenkins.getURL()
+                    + build1.getUrl()
+                    + build1.getAction(RebuildAction.class).getTaskUrl());
+            HtmlForm form = page.getFormByName("config");
+            jenkins.submit(form);
+
+            jenkins.waitUntilNoActivity();
+        }
+        FreeStyleBuild build2 = job.getLastBuild();
+        jenkins.assertBuildStatusSuccess(build2);
+        assertThat(build2.getNumber(), not(build1.getNumber()));
+        ParameterValue parameterValueBuild2 = build2.getParameterValues().stream()
+                .filter(WHideParameterValue.class::isInstance)
+                .findFirst()
+                .orElseThrow(AssertionError::new);
+        assertThat(parameterValueBuild2.getName(), is("MY_HIDDEN_PARAMETER"));
+        assertThat(parameterValueBuild2.getValue(), is("value-from-run"));
+    }
+}


### PR DESCRIPTION
I'm adding support of Rebuild plugin to the Hidden Parameter plugin as explained [there](https://github.com/jenkinsci/rebuild-plugin/blob/8a1be5d755ab31fe1588eb63c1a5ba5d11765b03/src/main/java/com/sonyericsson/rebuild/RebuildParameterProvider.java#L33-L70).
I needed to do this change because the hidden parameter values are not propagated to the rebuilt build.

I took inspiration from [MatrixCombinationsRebuildParameterProvider](https://github.com/jenkinsci/matrix-combinations-plugin/blob/a79731ab474c274000ce5b5251338605b39d3065/src/main/java/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsRebuildParameterProvider.java).

### Testing done

The change was only tested with unit tests.

I don't have a simple Jenkins instance in my hand (ours is running in Kubernetes with CASC, making this kind of tests difficult). But if there's a simple way to do it I would be happy to do it.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
